### PR TITLE
Created error messageType

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dnspython~=2.0.0
 pymongo~=3.11.0
 Flask~=1.1.2
-dataclasses~=0.7
+dataclasses~=0.7; python_version < '3.7'
 gevent~=20.9.0
 Flask-Sockets~=0.2.1


### PR DESCRIPTION
- Removed "success" field from all messages
- New messageType "error":
```
{
    "messageType": "error",
    "matchId": "some match id idk",
    "error": "the error message",
    "command": "the command that was used"
}
```
- Use the `error_msg` function to create these messages

- Added python_version marker for dataclasses so that it only installs when using python 3.6 or lower (since py 3.7 dataclasses are in stdlib and don't need to be installed)